### PR TITLE
allow local

### DIFF
--- a/lib/craft/application.ex
+++ b/lib/craft/application.ex
@@ -78,6 +78,11 @@ defmodule Craft.Application do
   else
     defp set_nexus_logger, do: :noop
     defp silence_sasl_logger, do: :noop
-    defp ensure_disterl!, do: raise("Craft requires the node to be in distributed mode.")
+
+    defp ensure_disterl! do
+      if !Application.get_env(:craft, :allow_local?, false) do
+        raise("Craft requires the node to be in distributed mode. use `config :craft, allow_local?: true` to override")
+      end
+    end
   end
 end


### PR DESCRIPTION
Feel free to close this and do it however you think best, but I need some way to be able to boot our application not in distributed mode (i.e. for testing where we are using stubs)
Completely removing craft from the test environment doesn't seem viable since we still use some things, i.e. `use Craft.Machine` to define our machine implementation, as well as in some distributed tests where we use the actual craft not the stubs.