### PR TITLE
include sandbox and local dev adapter

### DIFF
--- a/lib/craft/adapter/local.ex
+++ b/lib/craft/adapter/local.ex
@@ -105,7 +105,7 @@ defmodule Craft.Adapter.Local do
   def handle_call({:query, group, query}, from, state) do
     %{machine: machine, machine_state: machine_state} = Map.get(state.groups, group)
 
-    case machine.handle_query(query, {self(), from}, machine_state) do
+    case machine.handle_query(query, {:direct, from}, machine_state) do
       {:reply, response} -> {:reply, response, state}
       :noreply -> {:noreply, state}
     end

--- a/lib/craft/adapter/sandbox.ex
+++ b/lib/craft/adapter/sandbox.ex
@@ -5,8 +5,6 @@ defmodule Craft.Adapter.Sandbox do
 
   alias Craft.Adapter.Local
 
-  @custom_lookup Application.compile_env(:craft, __MODULE__, [])[:custom_lookup]
-
   # Passthrough
   for {func, arity} <- [discover: 2, transfer_leadership: 2, add_member: 2, holding_lease?: 1, cached_info: 1] do
     args = Macro.generate_arguments(arity, __MODULE__)
@@ -118,9 +116,9 @@ defmodule Craft.Adapter.Sandbox do
       end)
 
     {response, state} =
-      if is_nil(response) && @custom_lookup do
+      if is_nil(response) && is_atom(custom_lookup()) do
         Enum.reduce_while(pids, nil, fn pid, _acc ->
-          case @custom_lookup.lookup(pid) do
+          case custom_lookup().lookup(pid) do
             nil ->
               {:cont, {nil, state}}
 
@@ -178,5 +176,9 @@ defmodule Craft.Adapter.Sandbox do
     else
       state
     end
+  end
+
+  defp custom_lookup do
+    Application.get_env(:craft, __MODULE__, [])[:custom_lookup]
   end
 end


### PR DESCRIPTION
This PR assumes the changes made in the parallel-query-support PR.

Usecase:

For development, application users can use the Local adapter to run craft on a single node without any of the consensus checks since there will only ever be one node using this configuration.

For testing, the sandbox can be used to have an isolated store per test just like ecto. This allows us to use the real state machine in tests but without having to run synchronously and cleanup. Note, if using rocksdb in the state machine, it can be configured to run in-memory only with the data_dir starting with a "/" and the db options including `[env: :memenv]`

In the application, an adapter interface would be defined like
```elixir
defmodule MyApp.Store do
  @craft Application.compile_env(:myapp, :store_backend, Craft)

  def get(key, group) do
    @craft.query({:get, key}, group, [])
  end

  ...etc
end

Additionally a custom_lookup can be configured by the app to allow the sandbox to use app specific ways of associating a process with a running sandbox, i.e. `allow`ing a process by name, and using a lookup through a registry. This enables things like "allowing" a process before it's actually running.

TODO: Add docs on how to use it.