### PR TITLE
Supports 3-tuple errors in Craft.Machine

### DIFF
--- a/lib/craft/machine.ex
+++ b/lib/craft/machine.ex
@@ -865,6 +865,11 @@ defmodule Craft.Machine do
           GenServer.reply(from, error)
 
           state
+
+        {:error, _, _} = error ->
+          GenServer.reply(from, error)
+
+          state
       end
 
     {:noreply, %{state | read_index_tasks: Map.delete(state.read_index_tasks, ref)}}


### PR DESCRIPTION
Sometimes when starting craft I have 3-tuple errors. They are not always 3-tuple because errors like `timeout` in consensus are still 2-tuple. I wasn't sure we should mess with the consensus errors so I just made machine support 3-tuple also.