### PR TITLE
Fix Sandbox stop_member arity mismatch

### DIFF
--- a/lib/craft/backends/sandbox.ex
+++ b/lib/craft/backends/sandbox.ex
@@ -318,7 +318,7 @@ defmodule Craft.Sandbox do
     end
   end
 
-  def handle_call({:stop_member, name, _opts}, _from, state) do
+  def handle_call({:stop_member, name}, _from, state) do
     if state[name] do
       {:reply, :ok, Map.delete(state, name)}
     else

--- a/test/craft_sandbox_test.exs
+++ b/test/craft_sandbox_test.exs
@@ -17,4 +17,28 @@ defmodule CraftSandboxTest do
                Craft.Sandbox.async_command(:anything, :nonexistent_group, [])
     end
   end
+
+  describe "stop_member/1" do
+    test "stops a running member" do
+      name = :"stop_member_test_group_#{System.unique_integer([:positive])}"
+
+      :ok = Craft.Sandbox.start_group(name, [node()], Craft.SimpleMachine, [])
+
+      assert :ok = Craft.Sandbox.stop_member(name)
+
+      assert {:error, :unknown_group, %{}} = Craft.Sandbox.command({:put, :k, :v}, name, [])
+    end
+  end
+
+  describe "stop_group/1" do
+    test "stops the group's (sole) member" do
+      name = :"stop_group_test_group_#{System.unique_integer([:positive])}"
+
+      :ok = Craft.Sandbox.start_group(name, [node()], Craft.SimpleMachine, [])
+
+      assert :ok = Craft.Sandbox.stop_group(name)
+
+      assert {:error, :unknown_group, %{}} = Craft.Sandbox.command({:put, :k, :v}, name, [])
+    end
+  end
 end


### PR DESCRIPTION
`Craft.stop_member/1` crashed the Sandbox GenServer with `FunctionClauseError`. The client was sending two-tuple but the GenServer expected an unused opts in a three-tuple.

Dropped the unused `_opts` from the server clause so it matches the two-tuple the client actually sends. I decided to drop the `_opt` to mimic the same way that `start_member` works.

I added regression tests for both `stop_member/1` and `stop_group/1`.